### PR TITLE
Correction to spelling Constaints -> Constraints

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
+++ b/Triangulation_2/doc/Triangulation_2/Triangulation_2.txt
@@ -973,7 +973,7 @@ Triangulation (in blue) of the domain delimited by the red polygons.
 
 \cgalExample{Triangulation_2/polygon_triangulation.cpp}
 
-\section Section_2D_Triangulations_Constrained_Plus Constrained Triangulations with a Bidirectional Mapping between Constaints and Subconstraints
+\section Section_2D_Triangulations_Constrained_Plus Constrained Triangulations with a Bidirectional Mapping between Constraints and Subconstraints
 
 The class `Constrained_triangulation_plus_2<Tr>`
 provides a constrained triangulation with an additional data


### PR DESCRIPTION
A few more occurrences of the same spelling mistake here: https://github.com/CGAL/cgal/search?utf8=%E2%9C%93&q=Constaints&type=

